### PR TITLE
Updated API Key finding instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ The goal of this project is to automate the remaining manual steps. It does that
 
 ### Getting Your Unity Cloud Build Information ###
 
-You can find your API Key here: https://developer.cloud.unity3d.com/preferences/
-
-From there, navigate to: Settings > Cloud Build > API Settings > API Key
+You can find your API Key here: 
+  1. Open this url: https://dashboard.unity3d.com/develop/
+  1. Select your game's project name
+  1. Within that project's dashboard page, navigate to: Settings > Cloud Build > API Settings > API Key
 
 To get the rest of the information, go to the summary for your most recent build. In the URL you will see the necessary pieces:
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The goal of this project is to automate the remaining manual steps. It does that
 ### Getting Your Unity Cloud Build Information ###
 
 You can find your API Key here: https://developer.cloud.unity3d.com/preferences/
+From there, navigate to: Settings > Cloud Build > API Settings > API Key
 
 To get the rest of the information, go to the summary for your most recent build. In the URL you will see the necessary pieces:
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The goal of this project is to automate the remaining manual steps. It does that
 ### Getting Your Unity Cloud Build Information ###
 
 You can find your API Key here: https://developer.cloud.unity3d.com/preferences/
+
 From there, navigate to: Settings > Cloud Build > API Settings > API Key
 
 To get the rest of the information, go to the summary for your most recent build. In the URL you will see the necessary pieces:


### PR DESCRIPTION
The old instructions led to a 404, so these new ones give updated instructions to find a working API Key. Tested on Steam too, and appears to successfully upload this way for both Windows and Mac.